### PR TITLE
Remove uninlinable variables

### DIFF
--- a/classes/JSONlib.sc
+++ b/classes/JSONlib.sc
@@ -40,10 +40,10 @@ JSONlib {
 	}
 
 	prConvertToJson {|v|
-		var array;
+		var array, val;
 
 		if(customEncoder.notNil) {
-			var val = customEncoder.value(v);
+			val = customEncoder.value(v);
 			if(val.notNil) {
 				^val
 			}
@@ -103,9 +103,9 @@ JSONlib {
 	}
 
 	prConvertToSC { |v|
-		var res;
+		var res, val;
 		if(customDecoder.notNil) {
-			var val = customDecoder.value(v);
+			val = customDecoder.value(v);
 			if(val.notNil) {
 				^val
 			}

--- a/classes/JSONlib.sc
+++ b/classes/JSONlib.sc
@@ -73,7 +73,7 @@ JSONlib {
 			case
 			{ v == inf } { "inf".quote }
 			{ v == inf.neg } { "-inf".quote }
-			{v.asCompileString};
+			{ v.asCompileString }
 		}
 		{ v.isKindOf(Boolean) } { v.asBoolean }
 		{ v.isKindOf(SequenceableCollection) } {


### PR DESCRIPTION
We shouldn't use uninlinable variables in a quark, this fixes it.